### PR TITLE
Improve brake and reverse light trigger logic

### DIFF
--- a/lights/ivl_brakereverse_client.lua
+++ b/lights/ivl_brakereverse_client.lua
@@ -22,7 +22,6 @@ end
 function IVL.updateBrakeReverse(vehicle)
 	
 	local driver = getVehicleOccupant(vehicle)
-	if not driver then return false end
 
 	local reverseNew = false
 	local brakeNew = false
@@ -30,17 +29,18 @@ function IVL.updateBrakeReverse(vehicle)
 	local reverseOld = IVL.getData(vehicle, "reverse")
 	
 	local gear = getVehicleCurrentGear(vehicle)
-	local accelerateControl = getPedControlState(driver, "accelerate")
-	local brakeControl = getPedControlState(driver, "brake_reverse")
-	if not (accelerateControl and brakeControl) then
 
-		reverseNew =
-			gear == 0 and (brakeControl or reverseOld)
+	-- Turn on reverse light if in reverse gear
+	reverseNew = (gear == 0)
 
-		brakeNew = 
-			(gear == 0 and accelerateControl) or
-			(gear > 0 and brakeControl) or
-			(brakeOld and not(accelerateControl or brakeControl))
+	if driver then
+		local accelerateControl = getPedControlState(driver, "accelerate")
+		local brakeControl = getPedControlState(driver, "brake_reverse")
+
+		-- Turn on braking lights if in a forwards gear and brake key is pressed
+		-- or if in reverse gear and accelerate key is pressed
+		brakeNew = (gear > 0 and brakeControl)
+			or (gear == 0 and accelerateControl)
 	end
 	
 	if brakeOld ~= brakeNew then

--- a/lights/ivl_brakereverse_client.lua
+++ b/lights/ivl_brakereverse_client.lua
@@ -29,9 +29,10 @@ function IVL.updateBrakeReverse(vehicle)
 	local reverseOld = IVL.getData(vehicle, "reverse")
 	
 	local gear = getVehicleCurrentGear(vehicle)
+	local engineState = getVehicleEngineState(vehicle)
 
 	-- Turn on reverse light if in reverse gear
-	reverseNew = (gear == 0)
+	reverseNew = engineState and (gear == 0)
 
 	if driver then
 		local accelerateControl = getPedControlState(driver, "accelerate")
@@ -39,9 +40,12 @@ function IVL.updateBrakeReverse(vehicle)
 
 		-- Turn on braking lights if in a forwards gear and brake key is pressed
 		-- or if in reverse gear and accelerate key is pressed
-		brakeNew = (gear > 0 and brakeControl)
-			or (gear == 0 and accelerateControl)
+		brakeNew = engineState and
+			((gear > 0 and brakeControl)
+			or (gear == 0 and accelerateControl))
 	end
+
+	dxDrawText("gear: "..tostring(gear), 10, 15)
 	
 	if brakeOld ~= brakeNew then
 		setVehicleCustomLightsPower(vehicle, BRAKE_LIGHTS, brakeNew and 1 or 0)

--- a/lights/ivl_brakereverse_client.lua
+++ b/lights/ivl_brakereverse_client.lua
@@ -42,8 +42,6 @@ function IVL.updateBrakeReverse(vehicle)
 			or (gear == 0 and accelerateControl)
 	end
 
-	dxDrawText("gear: "..tostring(gear), 10, 15)
-	
 	if brakeOld ~= brakeNew then
 		setVehicleCustomLightsPower(vehicle, BRAKE_LIGHTS, brakeNew and 1 or 0)
 		setVehicleLightState(vehicle, 2, 1)

--- a/lights/ivl_brakereverse_client.lua
+++ b/lights/ivl_brakereverse_client.lua
@@ -31,18 +31,15 @@ function IVL.updateBrakeReverse(vehicle)
 	local gear = getVehicleCurrentGear(vehicle)
 	local engineState = getVehicleEngineState(vehicle)
 
-	-- Turn on reverse light if in reverse gear
-	reverseNew = engineState and (gear == 0)
+	reverseNew = engineState and gear == 0
 
 	if driver then
 		local accelerateControl = getPedControlState(driver, "accelerate")
 		local brakeControl = getPedControlState(driver, "brake_reverse")
 
-		-- Turn on braking lights if in a forwards gear and brake key is pressed
-		-- or if in reverse gear and accelerate key is pressed
 		brakeNew = engineState and
-			((gear > 0 and brakeControl)
-			or (gear == 0 and accelerateControl))
+			(gear > 0 and brakeControl)
+			or (gear == 0 and accelerateControl)
 	end
 
 	dxDrawText("gear: "..tostring(gear), 10, 15)


### PR DESCRIPTION
Brake lights will now only trigger when:
- vehicle is in a forwards gear (not reverse) and the brake key is pressed
- vehicle is in reverse gear and the accelarate key is pressed

Reverse light now only triggers when the vehicle is in reverse gear as per getVehicleCurrentGear. Reverse light shows even if the vehicle is unoccupied.

Both lights now only work if the engine is on.

I think this logic makes more sense. Before, the brake lights would turn on even after you released the brake pedal, which doesn't happen on any vehicle IRL or in default SA.

Tested with cvl_admiral.zip by @rifleh700 

![image](https://github.com/rifleh700/improved_vehicle_lights/assets/34967844/a829868c-fda7-4472-87f0-0717f5a0da09)
